### PR TITLE
Replace emoji icons with VS Code codicons in menus

### DIFF
--- a/media/webview.css
+++ b/media/webview.css
@@ -472,11 +472,22 @@ button .codicon {
 :is(.ag-theme-alpine-dark, .ag-theme-alpine) .ag-floating-top .ag-row {
     background-color: var(--vscode-list-inactiveSelectionBackground, #37373d) !important;
 }
-/* Frozen (pinned-left) column header: a 📌 marker before the column name,
+/* Frozen (pinned-left) column header: a pin marker before the column name,
    mirroring the frozen-row pin. The always-pinned '#' gutter (.row-index-header)
    is excluded so only user-frozen columns get the marker. */
 :is(.ag-theme-alpine-dark, .ag-theme-alpine) .ag-pinned-left-header .ag-header-cell:not(.row-index-header) .ag-header-cell-text::before {
-    content: '📌 ';
+    content: "\eba0";
+    font-family: "codicon";
+    font-weight: normal;
+    font-style: normal;
+    font-size: 16px;
+    line-height: 1;
+    display: inline-block;
+    vertical-align: middle;
+    margin-right: 4px;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: auto;
 }
 :is(.ag-theme-alpine-dark, .ag-theme-alpine) .ag-header-cell {
     font-weight: 600 !important;
@@ -792,6 +803,34 @@ button .codicon {
 }
 .row-index-header .ag-header-cell-text::before { display: none !important; }
 
+:is(.ag-theme-alpine-dark, .ag-theme-alpine) .ag-cell.row-index-pinned {
+    padding: 0 6px;
+}
+:is(.ag-theme-alpine-dark, .ag-theme-alpine) .ag-cell.row-index-pinned .ag-cell-value {
+    width: 100%;
+}
+.row-pin-cell {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    gap: 4px;
+}
+.row-pin-cell .codicon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    line-height: 16px;
+    flex-shrink: 0;
+    font-weight: normal;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+.row-pin-num {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 /* ── F2: Delimiter Badge ── */
 .delim-badge {
     font-size: 11px;
@@ -830,11 +869,12 @@ button .codicon {
     box-shadow: 0 3px 8px rgba(0,0,0,.35);
 }
 .col-context-menu.hidden { display: none; }
-.col-ctx-item { padding: 5px 12px; font-size: 12px; cursor: pointer; color: var(--vscode-menu-foreground, #ccc); }
+.col-ctx-item { display: flex; align-items: center; gap: 8px; padding: 5px 12px; font-size: 12px; cursor: pointer; color: var(--vscode-menu-foreground, #ccc); }
 .col-ctx-item:hover { background: var(--vscode-menu-selectionBackground, #094771); color: var(--vscode-menu-selectionForeground, #fff); }
 .col-ctx-separator { height: 1px; margin: 3px 0; background: var(--vscode-menu-border, #454545); pointer-events: none; }
 .col-ctx-item.danger { color: var(--vscode-errorForeground, #f48771); }
 .col-ctx-item.danger:hover { background: var(--vscode-inputValidation-errorBackground, #5a1d1d); color: #fff; }
+.col-ctx-item .codicon { font-size: 16px; width: 16px; flex-shrink: 0; font-weight: normal; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
 
 /* ── Row Context Menu ── */
 .row-context-menu {
@@ -848,10 +888,11 @@ button .codicon {
     box-shadow: 0 3px 8px rgba(0,0,0,.35);
 }
 .row-context-menu.hidden { display: none; }
-.row-ctx-item { padding: 5px 12px; font-size: 12px; cursor: pointer; color: var(--vscode-menu-foreground, #ccc); }
+.row-ctx-item { display: flex; align-items: center; gap: 8px; padding: 5px 12px; font-size: 12px; cursor: pointer; color: var(--vscode-menu-foreground, #ccc); }
 .row-ctx-item:hover { background: var(--vscode-menu-selectionBackground, #094771); color: var(--vscode-menu-selectionForeground, #fff); }
 .row-ctx-item.danger { color: var(--vscode-errorForeground, #f48771); }
 .row-ctx-item.danger:hover { background: var(--vscode-inputValidation-errorBackground, #5a1d1d); color: #fff; }
+.row-ctx-item .codicon { font-size: 16px; width: 16px; flex-shrink: 0; font-weight: normal; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
 
 /* AG Grid context menu danger items */
 .ag-menu-option.ctx-danger .ag-menu-option-text { color: var(--vscode-errorForeground, #f48771); }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "csv-grid-editor",
-  "version": "1.4.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "csv-grid-editor",
-      "version": "1.4.0",
+      "version": "1.10.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -220,22 +220,22 @@ export function getWebviewContent(
 
     <!-- Column context menu [F5] -->
     <div id="col-context-menu" class="col-context-menu hidden">
-        <div id="col-ctx-insert-left"  class="col-ctx-item"${isPreview ? ' style="display:none;"' : ''}>&#x2B05;&#xFE0F; Insert column left</div>
-        <div id="col-ctx-insert-right" class="col-ctx-item"${isPreview ? ' style="display:none;"' : ''}>&#x27A1;&#xFE0F; Insert column right</div>
+        <div id="col-ctx-insert-left"  class="col-ctx-item"${isPreview ? ' style="display:none;"' : ''}><i class="codicon codicon-arrow-left"></i><span class="col-ctx-label">Insert column left</span></div>
+        <div id="col-ctx-insert-right" class="col-ctx-item"${isPreview ? ' style="display:none;"' : ''}><i class="codicon codicon-arrow-right"></i><span class="col-ctx-label">Insert column right</span></div>
         <div class="col-ctx-separator"${isPreview ? ' style="display:none;"' : ''}></div>
-        <div id="col-ctx-rename"   class="col-ctx-item"${isPreview ? ' style="display:none;"' : ''}>&#x270F;&#xFE0F; Rename column</div>
+        <div id="col-ctx-rename"   class="col-ctx-item"${isPreview ? ' style="display:none;"' : ''}><i class="codicon codicon-edit"></i><span class="col-ctx-label">Rename column</span></div>
         <div class="col-ctx-separator"${isPreview ? ' style="display:none;"' : ''}></div>
-        <div id="col-ctx-select"   class="col-ctx-item">&#x2630; Select column</div>
+        <div id="col-ctx-select"   class="col-ctx-item"><i class="codicon codicon-list-selection"></i><span class="col-ctx-label">Select column</span></div>
         <div class="col-ctx-separator"></div>
-        <div id="col-ctx-freeze"   class="col-ctx-item">&#x1F4CC; Freeze column</div>
-        <div id="col-ctx-unfreeze" class="col-ctx-item" style="display:none;">&#x1F4CC; Unfreeze column</div>
+        <div id="col-ctx-freeze"   class="col-ctx-item"><i class="codicon codicon-pinned"></i><span class="col-ctx-label">Freeze column</span></div>
+        <div id="col-ctx-unfreeze" class="col-ctx-item" style="display:none;"><i class="codicon codicon-pin"></i><span class="col-ctx-label">Unfreeze column</span></div>
         <div class="col-ctx-separator"${isPreview ? ' style="display:none;"' : ''}></div>
-        <div id="col-ctx-delete"   class="col-ctx-item danger"${isPreview ? ' style="display:none;"' : ''}>&#x2715; Delete column</div>
+        <div id="col-ctx-delete"   class="col-ctx-item danger"${isPreview ? ' style="display:none;"' : ''}><i class="codicon codicon-trash"></i><span class="col-ctx-label">Delete column</span></div>
     </div>
 
     <!-- Row context menu -->
     <div id="row-context-menu" class="row-context-menu hidden">
-        <div id="row-ctx-delete" class="row-ctx-item danger">&#x2715; Delete row</div>
+        <div id="row-ctx-delete" class="row-ctx-item danger"><i class="codicon codicon-trash"></i><span class="row-ctx-label">Delete row</span></div>
     </div>
 
     <!-- Pagination bar [F7] -->

--- a/src/webview/features/delete-row-col.ts
+++ b/src/webview/features/delete-row-col.ts
@@ -163,6 +163,17 @@ function insertColumns(baseIndex: number, position: 'left' | 'right', count: num
 }
 
 // ── Custom context menu ───────────────────────────────────────────────────────
+function makeRowItem(label: string, iconClass: string, danger = false): HTMLDivElement {
+    const item = document.createElement('div');
+    item.className = 'row-ctx-item' + (danger ? ' danger' : '');
+    const icon = document.createElement('i');
+    icon.className = 'codicon ' + iconClass;
+    const span = document.createElement('span');
+    span.className = 'row-ctx-label';
+    span.textContent = label;
+    item.append(icon, span);
+    return item;
+}
 
 function hideMenu(): void {
     document.getElementById('row-context-menu')?.classList.add('hidden');
@@ -185,15 +196,11 @@ function showContextMenu(x: number, y: number, rowIndex: number | null, colId: s
     // ── Copy ──────────────────────────────────────────────────────────────────
     if (hasMultiSelection()) {
         // A range is selected — offer range copy, with and without header row.
-        const copyRange = document.createElement('div');
-        copyRange.className = 'row-ctx-item';
-        copyRange.textContent = 'Copy';
+        const copyRange = makeRowItem('Copy', 'codicon-copy');
         copyRange.addEventListener('click', () => { copySelection(false); hideMenu(); });
         menu.appendChild(copyRange);
 
-        const copyWithHeader = document.createElement('div');
-        copyWithHeader.className = 'row-ctx-item';
-        copyWithHeader.textContent = 'Copy with header';
+        const copyWithHeader = makeRowItem('Copy with header', 'codicon-copy');
         copyWithHeader.addEventListener('click', () => { copySelection(true); hideMenu(); });
         menu.appendChild(copyWithHeader);
 
@@ -207,9 +214,7 @@ function showContextMenu(x: number, y: number, rowIndex: number | null, colId: s
         const raw   = node?.data?.[colId];
         const value = raw != null ? String(raw) : '';
 
-        const copyItem = document.createElement('div');
-        copyItem.className = 'row-ctx-item';
-        copyItem.textContent = 'Copy';
+        const copyItem = makeRowItem('Copy', 'codicon-copy');
         copyItem.addEventListener('click', () => {
             navigator.clipboard.writeText(value).catch(() => {});
             hideMenu();
@@ -233,16 +238,12 @@ function showContextMenu(x: number, y: number, rowIndex: number | null, colId: s
             // freezes. "Unfreeze all rows" is a separate, explicit action.
             const clickedOrig = pinnedOrig;
             if (clickedOrig != null) {
-                const item = document.createElement('div');
-                item.className = 'row-ctx-item';
-                item.textContent = '📌 Unfreeze row';
+                const item = makeRowItem('Unfreeze row', 'codicon-pin');
                 item.addEventListener('click', () => { unfreezeRow(clickedOrig); hideMenu(); });
                 menu.appendChild(item);
             }
             if (frozenRowCount() > 1) {
-                const all = document.createElement('div');
-                all.className = 'row-ctx-item';
-                all.textContent = '📌 Unfreeze all rows';
+                const all = makeRowItem('Unfreeze all rows', 'codicon-pin');
                 all.addEventListener('click', () => { unfreezeAllRows(); hideMenu(); });
                 menu.appendChild(all);
             }
@@ -265,9 +266,7 @@ function showContextMenu(x: number, y: number, rowIndex: number | null, colId: s
             }
 
             if (origs.length > 0) {
-                const item = document.createElement('div');
-                item.className = 'row-ctx-item';
-                item.textContent = origs.length > 1 ? `📌 Freeze ${origs.length} rows` : '📌 Freeze row';
+                const item = makeRowItem(origs.length > 1 ? `Freeze ${origs.length} rows` : 'Freeze row', 'codicon-pinned');
                 item.addEventListener('click', () => { freezeRows(origs); hideMenu(); });
                 menu.appendChild(item);
 
@@ -289,18 +288,14 @@ function showContextMenu(x: number, y: number, rowIndex: number | null, colId: s
         const topEdge    = inSel ? Math.min(...selectedRows) : rowIndex;
         const bottomEdge = inSel ? Math.max(...selectedRows) : rowIndex;
 
-        const insertAbove = document.createElement('div');
-        insertAbove.className = 'row-ctx-item';
-        insertAbove.textContent = count > 1 ? `Insert ${count} rows above` : 'Insert row above';
+        const insertAbove = makeRowItem(count > 1 ? `Insert ${count} rows above` : 'Insert row above', 'codicon-arrow-up');
         insertAbove.addEventListener('click', () => {
             insertRows(topEdge, 'above', count);
             hideMenu();
         });
         menu.appendChild(insertAbove);
 
-        const insertBelow = document.createElement('div');
-        insertBelow.className = 'row-ctx-item';
-        insertBelow.textContent = count > 1 ? `Insert ${count} rows below` : 'Insert row below';
+        const insertBelow = makeRowItem(count > 1 ? `Insert ${count} rows below` : 'Insert row below', 'codicon-arrow-down');
         insertBelow.addEventListener('click', () => {
             insertRows(bottomEdge, 'below', count);
             hideMenu();
@@ -323,10 +318,7 @@ function showContextMenu(x: number, y: number, rowIndex: number | null, colId: s
             ? selectedRows
             : [rowIndex];
 
-        const label = rowIndices.length > 1 ? `Delete ${rowIndices.length} rows` : 'Delete row';
-        const delRowItem = document.createElement('div');
-        delRowItem.className = 'row-ctx-item danger';
-        delRowItem.textContent = label;
+        const delRowItem = makeRowItem(rowIndices.length > 1 ? `Delete ${rowIndices.length} rows` : 'Delete row', 'codicon-trash', true);
         delRowItem.addEventListener('click', () => {
             deleteRows(rowIndices);
             hideMenu();
@@ -340,9 +332,7 @@ function showContextMenu(x: number, y: number, rowIndex: number | null, colId: s
         const selectedCols = getSelectedColIndices();
         const useMulti = selectedCols.length > 1 && selectedCols.includes(colIndex);
 
-        const delColItem = document.createElement('div');
-        delColItem.className = 'row-ctx-item danger';
-        delColItem.textContent = useMulti ? `Delete ${selectedCols.length} columns` : 'Delete column';
+        const delColItem = makeRowItem(useMulti ? `Delete ${selectedCols.length} columns` : 'Delete column', 'codicon-trash', true);
         delColItem.addEventListener('click', () => {
             if (useMulti) deleteColumns(selectedCols);
             else if (colId) deleteColumn(colId);
@@ -431,8 +421,10 @@ export function setupDeleteRowCol(): void {
         const rowIndex = riStr != null ? parseInt(riStr, 10) : null;
 
         // For a pinned (frozen) row, resolve which row it is independently of AG
-        // Grid's pinned-row index scheme: the '#' gutter cell renders "📌<origIndex>"
-        // (builder.ts valueGetter), so read that from the matching row in the band.
+        // Grid's pinned-row index scheme: the '#' gutter cell renders a pin icon +
+        // the origIndex (builder.ts cellRenderer). The icon is a ::before glyph with
+        // no text node, so the cell's textContent is just the number - read it from
+        // the matching row in the band.
         let pinnedOrig: number | null = null;
         if (isPinnedRow && agRow && riStr != null) {
             const ft = agRow.closest('.ag-floating-top');

--- a/src/webview/features/freeze-columns.ts
+++ b/src/webview/features/freeze-columns.ts
@@ -67,23 +67,25 @@ export function setupFreezeColumns(): void {
         const selectedCols = getSelectedColIndices();
         const n = selectedCols.length > 1 && selectedCols.includes(colIndex) ? selectedCols.length : 1;
 
-        const freezeEl   = document.getElementById('col-ctx-freeze');
+        const setLabel = (el: HTMLElement | null, text: string): void => {
+            const lbl = el?.querySelector('.col-ctx-label');
+            if (lbl) lbl.textContent = text;
+        };
+
+        const freezeEl = document.getElementById('col-ctx-freeze');
         const unfreezeEl = document.getElementById('col-ctx-unfreeze');
         if (freezeEl) {
-            freezeEl.style.display = isPinned ? 'none' : 'block';
-            freezeEl.textContent   = n > 1 ? `📌 Freeze ${n} columns` : '📌 Freeze column';
+            freezeEl.style.display = isPinned ? 'none' : 'flex';
+            setLabel(freezeEl, n > 1 ? `Freeze ${n} columns` : 'Freeze column');
         }
         if (unfreezeEl) {
-            unfreezeEl.style.display = isPinned ? 'block' : 'none';
-            unfreezeEl.textContent   = n > 1 ? `📌 Unfreeze ${n} columns` : '📌 Unfreeze column';
+            unfreezeEl.style.display = isPinned ? 'flex' : 'none';
+            setLabel(unfreezeEl, n > 1 ? `Unfreeze ${n} columns` : 'Unfreeze column');
         }
 
-        const delEl = document.getElementById('col-ctx-delete');
-        if (delEl)  delEl.textContent  = n > 1 ? `✕ Delete ${n} columns`      : '✕ Delete column';
-        const insL = document.getElementById('col-ctx-insert-left');
-        if (insL)   insL.textContent   = n > 1 ? `⬅️ Insert ${n} columns left`  : '⬅️ Insert column left';
-        const insR = document.getElementById('col-ctx-insert-right');
-        if (insR)   insR.textContent   = n > 1 ? `➡️ Insert ${n} columns right` : '➡️ Insert column right';
+        setLabel(document.getElementById('col-ctx-delete'), n > 1 ? `Delete ${n} columns` : 'Delete column');
+        setLabel(document.getElementById('col-ctx-insert-left'), n > 1 ? `Insert ${n} columns left` : 'Insert column left');
+        setLabel(document.getElementById('col-ctx-insert-right'), n > 1 ? `Insert ${n} columns right` : 'Insert column right');
 
         menu.dataset.colId = colId;
         menu.style.left    = e.clientX + 'px';

--- a/src/webview/grid/builder.ts
+++ b/src/webview/grid/builder.ts
@@ -122,21 +122,31 @@ export function buildGrid(): void {
         headerName: '#',
         colId: 'row-index',
         headerClass: 'row-index-header',
-        // The frozen (pinned) row shows a 📌 marker + its original row number so it
+        // The frozen (pinned) row shows a pin marker + its original row number so it
         // reads as "the frozen row N", not a duplicate of the body row that now
         // sits at display position N (the body renumbers positionally once a row is
         // pinned out). "Show only duplicates" mode shows the original number; every
         // other row shows its live display position.
         valueGetter: (p: any) => {
-            if (p.node.rowPinned && p.data?._origIndex != null) return '📌' + p.data._origIndex;
+            if (p.node.rowPinned && p.data?._origIndex != null) return p.data._origIndex;
             if (state.dupShowOnly && p.data?._origIndex != null) return p.data._origIndex;
             return p.node.rowIndex + 1;
         },
+        cellRenderer: (p: any) => {
+            const txt = p.value == null ? '' : String(p.value);
+            if (p.node.rowPinned) {
+                return '<span class="row-pin-cell">'
+                    + '<i class="codicon codicon-pinned"></i>'
+                    + '<span class="row-pin-num">' + txt + '</span>'
+                    + '</span>';
+            }
+            return txt;
+        },
+        cellClass: (p: any) => p.node.rowPinned ? 'row-index-cell row-index-pinned' : 'row-index-cell',
         width: 48, minWidth: 36, maxWidth: 80,
         pinned: 'left',
         suppressHeaderMenuButton: true, sortable: false, filter: false,
         editable: false, resizable: false, suppressMovable: true,
-        cellClass: 'row-index-cell',
     }];
 
     for (let c = 0; c < numCols; c++) {


### PR DESCRIPTION
Context menus (column & row), the pin markers on headers/gutter, and dynamic labels were using emojis, which render inconsistently across platforms and caused misaligned icons and uneven spacing.

Switched to codicons (already loaded in the webview).

Added "Unfreeze all columns/rows (N)" to the context menu. It appears when multiple items are frozen, allowing users to clear the entire freeze set at once.

Before:
<img width="417" height="258" alt="old_icon" src="https://github.com/user-attachments/assets/a970c2c0-7b60-4912-af4f-ad20d2afd625" />

After:
<img width="456" height="279" alt="new_icon" src="https://github.com/user-attachments/assets/54580caf-a6a3-41f2-bcc5-48770e83e4f5" />

Unfreeze all:
<img width="459" height="252" alt="unfreeze" src="https://github.com/user-attachments/assets/c67880d2-8128-47d5-ab71-98d6c61bc82a" />

