### PR TITLE
Add select-all by clicking the corner

### DIFF
--- a/media/webview.css
+++ b/media/webview.css
@@ -790,6 +790,7 @@ button .codicon {
     user-select: none;
     cursor: pointer;
 }
+.row-index-header { cursor: pointer; }
 .row-index-header .ag-header-cell-text::before { display: none !important; }
 
 /* ── F2: Delimiter Badge ── */

--- a/src/webview/features/range-select.ts
+++ b/src/webview/features/range-select.ts
@@ -484,9 +484,18 @@ export function setupRangeSelect(): void {
     // one delegated listener covers every rebuild.
     const container = document.getElementById('grid-container');
     container?.addEventListener('click', (e: MouseEvent) => {
-        if (!e.shiftKey) return;
         const headerCell = (e.target as HTMLElement).closest<HTMLElement>('.ag-header-cell[col-id]');
         const colId = headerCell?.getAttribute('col-id');
+
+        if (colId === 'row-index') {
+            e.preventDefault();
+            e.stopPropagation();
+            if (selActive && selType === 'all') clearRangeSelection();
+            else selectAll();
+            return;
+        }
+
+        if (!e.shiftKey) return;
         if (!colId || !colId.startsWith('col_')) return;
         e.preventDefault();
         e.stopPropagation();


### PR DESCRIPTION
Clicking the top-left corner cell (# column) now selects the entire table, matching Excel/Google Sheets behavior, click again to deselect.

<img width="297" height="238" alt="select" src="https://github.com/user-attachments/assets/b90f018a-3979-4935-8751-5c05bf535ce9" />
