### PR TITLE
Fix context menu and rename-popup positioning

### DIFF
--- a/src/webview/features/freeze-columns.ts
+++ b/src/webview/features/freeze-columns.ts
@@ -86,8 +86,12 @@ export function setupFreezeColumns(): void {
         if (insR)   insR.textContent   = n > 1 ? `➡️ Insert ${n} columns right` : '➡️ Insert column right';
 
         menu.dataset.colId = colId;
-        menu.style.left    = e.clientX + 'px';
-        menu.style.top     = e.clientY + 'px';
         menu.classList.remove('hidden');
+        const vw = window.innerWidth;
+        const vh = window.innerHeight;
+        const mw = menu.offsetWidth || 200;
+        const mh = menu.offsetHeight || 240;
+        menu.style.left = Math.max(4, Math.min(e.clientX, vw - mw - 4)) + 'px';
+        menu.style.top = Math.max(4, Math.min(e.clientY, vh - mh - 4)) + 'px';
     });
 }

--- a/src/webview/features/rename-column.ts
+++ b/src/webview/features/rename-column.ts
@@ -67,7 +67,10 @@ export function setupRenameColumn(): void {
     document.getElementById('col-ctx-rename')?.addEventListener('click', () => {
         const colId = colMenu?.dataset.colId;
         colMenu?.classList.add('hidden');
-        if (colId && colId !== 'row-index') openRenamePopover(colId, null);
+        if (colId && colId !== 'row-index') {
+            const headerCell = document.querySelector<HTMLElement>(`.ag-header-cell[col-id="${colId}"]`);
+            openRenamePopover(colId, headerCell);
+        }
     });
 
     document.getElementById('rename-ok')?.addEventListener('click', commitRename);


### PR DESCRIPTION
Fixed column header menu positioning:

- Rename popup: Now correctly anchors directly below the header cell when opened via the context menu.
- Context menu: Clamps to the viewport to prevent off-screen overflow when right-clicking near the right edge.

Before:
<img width="798" height="168" alt="old_popup" src="https://github.com/user-attachments/assets/a94a73d0-d024-4f4a-a5b7-8b34ef553921" />
<img width="218" height="266" alt="old_menu" src="https://github.com/user-attachments/assets/db0cd4b7-29e7-468a-8d90-40cfd0b53bf2" />

After:
<img width="324" height="156" alt="new_popup" src="https://github.com/user-attachments/assets/8f333c9e-8ef0-41fa-8720-fe0600b8efba" />
<img width="355" height="241" alt="new_menu" src="https://github.com/user-attachments/assets/bf87a3c2-18fe-40ea-911e-567b28919f6a" />
