### PR TITLE
Add select-all checkbox to row filter

### DIFF
--- a/media/webview.css
+++ b/media/webview.css
@@ -673,6 +673,31 @@ body.vscode-high-contrast #grid-container.cm-on {
 .csv-filter-input:focus { border-color: var(--vscode-focusBorder, #007fd4); }
 .csv-filter-input::placeholder { color: var(--vscode-input-placeholderForeground, #666); }
 .csv-filter-actions { display: flex; gap: 8px; margin: 5px 0 6px; }
+.csv-filter-master {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px;
+    margin: 6px 0;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    border-radius: 3px;
+    position: relative;
+}
+.csv-filter-master::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -4px;
+    height: 1px;
+    background: var(--vscode-panel-border, #3c3c3c);
+}
+.csv-filter-master:hover { background: var(--vscode-list-hoverBackground, #2a2d2e); }
+.csv-filter-master input { cursor: pointer; margin: 0; flex: none; accent-color: var(--vscode-focusBorder, #007fd4); }
+.csv-filter-master-label { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.csv-filter-master-count { font-size: 11px; font-weight: 400; opacity: 0.6; flex: none; }
 .csv-filter-link {
     background: none;
     border: none;
@@ -689,8 +714,8 @@ body.vscode-high-contrast #grid-container.cm-on {
 .csv-filter-value-row {
     display: flex;
     align-items: center;
-    gap: 7px;
-    padding: 2px;
+    gap: 6px;
+    padding: 2px 6px;
     border-radius: 2px;
     cursor: pointer;
     white-space: nowrap;

--- a/media/webview.css
+++ b/media/webview.css
@@ -1259,11 +1259,3 @@ body.vscode-high-contrast #grid-container.cm-on {
     color: var(--vscode-charts-orange, #d18616) !important;
     font-weight: 700 !important;
 }
-/* Override AG Grid's default Alpine popup styles to match the extension's popovers. */
-:is(.ag-theme-alpine-dark, .ag-theme-alpine) .ag-popup .ag-menu,
-:is(.ag-theme-alpine-dark, .ag-theme-alpine) .ag-popup .ag-filter {
-    background: var(--vscode-menu-background, #252526);
-    border: 1px solid var(--vscode-menu-border, #454545);
-    border-radius: 4px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, .45);
-}

--- a/media/webview.css
+++ b/media/webview.css
@@ -1259,3 +1259,11 @@ body.vscode-high-contrast #grid-container.cm-on {
     color: var(--vscode-charts-orange, #d18616) !important;
     font-weight: 700 !important;
 }
+/* Override AG Grid's default Alpine popup styles to match the extension's popovers. */
+:is(.ag-theme-alpine-dark, .ag-theme-alpine) .ag-popup .ag-menu,
+:is(.ag-theme-alpine-dark, .ag-theme-alpine) .ag-popup .ag-filter {
+    background: var(--vscode-menu-background, #252526);
+    border: 1px solid var(--vscode-menu-border, #454545);
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, .45);
+}

--- a/media/webview.css
+++ b/media/webview.css
@@ -715,8 +715,8 @@ body.vscode-high-contrast #grid-container.cm-on {
     display: flex;
     align-items: center;
     gap: 6px;
-    padding: 2px 6px;
-    border-radius: 2px;
+    padding: 4px 6px;
+    border-radius: 3px;
     cursor: pointer;
     white-space: nowrap;
     overflow: hidden;

--- a/src/webview/grid/filter.ts
+++ b/src/webview/grid/filter.ts
@@ -16,6 +16,7 @@ export function createCombinedFilter(colType: ColType): any {
         _searchQuery = '';
         truncated = false;
         _renderValuesList: (() => void) | null = null;
+        _displayedValues: string[] = [];
 
         init(params: any) {
             this.params = params;
@@ -291,31 +292,45 @@ export function createCombinedFilter(colType: ColType): any {
             searchInp.value = this._searchQuery;
             valSec.appendChild(searchInp);
 
-            const actions = document.createElement('div');
-            actions.className = 'csv-filter-actions';
-            const selAll = document.createElement('button');
-            selAll.className = 'csv-filter-link';
-            selAll.textContent = 'Select All';
-            const deselAll = document.createElement('button');
-            deselAll.className = 'csv-filter-link';
-            deselAll.textContent = 'Deselect All';
-            actions.appendChild(selAll);
-            actions.appendChild(deselAll);
-            valSec.appendChild(actions);
+            const masterRow = document.createElement('label');
+            masterRow.className = 'csv-filter-master';
+            const masterCb = document.createElement('input');
+            masterCb.type = 'checkbox';
+            const masterLabel = document.createElement('span');
+            masterLabel.className = 'csv-filter-master-label';
+            masterLabel.textContent = '(Select all)';
+            const masterCount = document.createElement('span');
+            masterCount.className = 'csv-filter-master-count';
+            masterRow.appendChild(masterCb);
+            masterRow.appendChild(masterLabel);
+            masterRow.appendChild(masterCount);
+            valSec.appendChild(masterRow);
 
             const listDiv = document.createElement('div');
             listDiv.className = 'csv-filter-values-list';
             valSec.appendChild(listDiv);
 
+            const syncMaster = () => {
+                const displayed = this._displayedValues;
+                const total = displayed.length;
+                let checked = 0;
+                for (const v of displayed) if (this.checkedValues.has(v)) checked++;
+                masterCb.checked = total > 0 && checked === total;
+                masterCb.indeterminate = checked > 0 && checked < total;
+                masterCb.disabled = total === 0;
+                masterCount.textContent = total > 0 ? `${checked} / ${total}` : '';
+            };
+
             const renderList = () => {
                 listDiv.innerHTML = '';
                 const q = this._searchQuery.toLowerCase();
 
-                // Only values that pass ALL active conditions
                 let items: { label: string; value: string; isBlank: boolean }[] = [];
                 if (this._showBlankInList()) items.push({ label: '(Blank)', value: '__blank__', isBlank: true });
                 this._valuesPassingCondition().forEach(v => items.push({ label: v, value: v, isBlank: false }));
                 if (q) items = items.filter(it => it.label.toLowerCase().includes(q));
+
+                this._displayedValues = items.map(it => it.value);
 
                 if (items.length === 0) {
                     const empty = document.createElement('div');
@@ -324,6 +339,7 @@ export function createCombinedFilter(colType: ColType): any {
                         ? 'No values match this condition'
                         : 'No matching values';
                     listDiv.appendChild(empty);
+                    syncMaster();
                     return;
                 }
                 items.forEach(item => {
@@ -335,6 +351,7 @@ export function createCombinedFilter(colType: ColType): any {
                     cb.addEventListener('change', () => {
                         if (cb.checked) this.checkedValues.add(item.value);
                         else this.checkedValues.delete(item.value);
+                        syncMaster();
                         this.params.filterChangedCallback();
                     });
                     const span = document.createElement('span');
@@ -350,21 +367,21 @@ export function createCombinedFilter(colType: ColType): any {
                     note.textContent = 'Showing first 2000 unique values';
                     listDiv.appendChild(note);
                 }
+                syncMaster();
             };
 
             this._renderValuesList = renderList;
 
-            selAll.addEventListener('click', () => {
-                this._valuesPassingCondition().forEach(v => this.checkedValues.add(v));
-                if (this._showBlankInList()) this.checkedValues.add('__blank__');
+            masterCb.addEventListener('change', () => {
+                const check = masterCb.checked;
+                for (const v of this._displayedValues) {
+                    if (check) this.checkedValues.add(v);
+                    else this.checkedValues.delete(v);
+                }
                 renderList();
                 this.params.filterChangedCallback();
             });
-            deselAll.addEventListener('click', () => {
-                this.checkedValues.clear();
-                renderList();
-                this.params.filterChangedCallback();
-            });
+
             searchInp.addEventListener('input', () => {
                 this._searchQuery = searchInp.value;
                 renderList();

--- a/src/webview/grid/filter.ts
+++ b/src/webview/grid/filter.ts
@@ -378,6 +378,7 @@ export function createCombinedFilter(colType: ColType): any {
                     if (check) this.checkedValues.add(v);
                     else this.checkedValues.delete(v);
                 }
+                if (check && this._showBlankInList()) this.checkedValues.add('__blank__');
                 renderList();
                 this.params.filterChangedCallback();
             });

--- a/src/webview/grid/filter.ts
+++ b/src/webview/grid/filter.ts
@@ -319,6 +319,7 @@ export function createCombinedFilter(colType: ColType): any {
                 masterCb.indeterminate = checked > 0 && checked < total;
                 masterCb.disabled = total === 0;
                 masterCount.textContent = total > 0 ? `${checked} / ${total}` : '';
+                masterLabel.textContent = this._searchQuery ? 'Select all matches' : 'Select all';
             };
 
             const renderList = () => {
@@ -378,7 +379,6 @@ export function createCombinedFilter(colType: ColType): any {
                     if (check) this.checkedValues.add(v);
                     else this.checkedValues.delete(v);
                 }
-                if (check && this._showBlankInList()) this.checkedValues.add('__blank__');
                 renderList();
                 this.params.filterChangedCallback();
             });

--- a/src/webview/grid/filter.ts
+++ b/src/webview/grid/filter.ts
@@ -298,7 +298,7 @@ export function createCombinedFilter(colType: ColType): any {
             masterCb.type = 'checkbox';
             const masterLabel = document.createElement('span');
             masterLabel.className = 'csv-filter-master-label';
-            masterLabel.textContent = '(Select all)';
+            masterLabel.textContent = 'Select all';
             const masterCount = document.createElement('span');
             masterCount.className = 'csv-filter-master-count';
             masterRow.appendChild(masterCb);


### PR DESCRIPTION
Completes #19 by replacing "Select All / Deselect All" with a tri-state master checkbox. It targets only visible results matching active filters and search. Updates are fast since they only run on visible items, avoiding rebuilding the list or breaking existing filter logic.

<img width="443" height="471" alt="image" src="https://github.com/user-attachments/assets/20ea44b7-6459-4bf0-9361-a5f8c814e8c1" />
