### PR TITLE
Use the correct unpin icon for the Unfreeze menu entries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "csv-grid-editor",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "csv-grid-editor",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",
         "@types/vscode": "^1.80.0",
-        "@vscode/codicons": "^0.0.45",
+        "@vscode/codicons": "^0.0.46-24",
         "ag-grid-community": "32.3.3",
         "esbuild": "^0.27.4",
         "typescript": "^5.3.0"
@@ -480,9 +480,9 @@
       "license": "MIT"
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.45",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45.tgz",
-      "integrity": "sha512-1KAZ7XCMagp5Gdrlr4bbbcAqgcIL623iO1wW6rfcSVGAVUQvR0WP7bQx1SbJ11gmV3fdQTSEFIJQ/5C+HuVasw==",
+      "version": "0.0.46-24",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-24.tgz",
+      "integrity": "sha512-KIDWUYxG6eh+DHRg+3G4bS487T+g1ZkLfB4HylOBbCcHsvLdfLMRM/m92DS1Ljhi8nglLr9ucwwWhHTEAC+DpA==",
       "dev": true,
       "license": "CC-BY-4.0"
     },

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@types/vscode": "^1.80.0",
-    "@vscode/codicons": "^0.0.45",
+    "@vscode/codicons": "^0.0.46-24",
     "ag-grid-community": "32.3.3",
     "esbuild": "^0.27.4",
     "typescript": "^5.3.0"

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -238,8 +238,8 @@ export function getWebviewContent(
         <div id="col-ctx-select"   class="col-ctx-item"><i class="codicon codicon-list-selection"></i><span class="col-ctx-label">Select column</span></div>
         <div class="col-ctx-separator"></div>
         <div id="col-ctx-freeze"   class="col-ctx-item"><i class="codicon codicon-pinned"></i><span class="col-ctx-label">Freeze column</span></div>
-        <div id="col-ctx-unfreeze" class="col-ctx-item" style="display:none;"><i class="codicon codicon-pin"></i><span class="col-ctx-label">Unfreeze column</span></div>
-        <div id="col-ctx-unfreeze-all" class="col-ctx-item" style="display:none;"><i class="codicon codicon-pin"></i><span class="col-ctx-label">Unfreeze all columns</span></div>
+        <div id="col-ctx-unfreeze" class="col-ctx-item" style="display:none;"><i class="codicon codicon-unpin"></i><span class="col-ctx-label">Unfreeze column</span></div>
+        <div id="col-ctx-unfreeze-all" class="col-ctx-item" style="display:none;"><i class="codicon codicon-unpin"></i><span class="col-ctx-label">Unfreeze all columns</span></div>
         <div class="col-ctx-separator"${isPreview ? ' style="display:none;"' : ''}></div>
         <div id="col-ctx-delete"   class="col-ctx-item danger"${isPreview ? ' style="display:none;"' : ''}><i class="codicon codicon-trash"></i><span class="col-ctx-label">Delete column</span></div>
     </div>

--- a/src/webview/features/delete-row-col.ts
+++ b/src/webview/features/delete-row-col.ts
@@ -237,7 +237,7 @@ function showContextMenu(x: number, y: number, rowIndex: number | null, colId: s
             // Right-clicked a pinned (frozen) row -> unfreeze just that row.
             const clickedOrig = pinnedOrig;
             if (clickedOrig != null) {
-                const item = makeRowItem('Unfreeze row', 'codicon-pin');
+                const item = makeRowItem('Unfreeze row', 'codicon-unpin');
                 item.addEventListener('click', () => { unfreezeRow(clickedOrig); hideMenu(); });
                 menu.appendChild(item);
             }
@@ -264,7 +264,7 @@ function showContextMenu(x: number, y: number, rowIndex: number | null, colId: s
         // "Unfreeze all rows (N)" sits below the per-row items, shown on any row
         // while more than one row is frozen - mirrors "Unfreeze all columns".
         if (frozenRowCount() > 1) {
-            const all = makeRowItem(`Unfreeze all rows (${frozenRowCount()})`, 'codicon-pin');
+            const all = makeRowItem(`Unfreeze all rows (${frozenRowCount()})`, 'codicon-unpin');
             all.addEventListener('click', () => { unfreezeAllRows(); hideMenu(); });
             menu.appendChild(all);
         }


### PR DESCRIPTION
Unfreeze now uses `codicon-unpin`, which is the `codicon-pinned` geometry with a slash across it.

`codicon-unpin` was added in codicons 0.0.46, so this bumps `^0.0.45` to `0.0.46-24` (the current `latest` dist-tag; 0.0.46 ships only as prereleases).