### PR TITLE
Add XML export

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ For files larger than 10 MB you get a quick menu to open the full file, preview 
   - The status bar shows the selection size plus live `Count / Sum / Avg / Min / Max`
 - **Export as JSON** - Convert the current filtered and sorted view to a JSON array of objects via the native VS Code save dialog. Column headers become the keys and numbers and booleans come out typed, while values that would lose information (IDs with leading zeros, very large numbers) stay strings. Columns you have hidden in the column chooser are left out, the same as copy.
 - **Export as JSON Lines** - The same view as JSON Lines (NDJSON), one object per line, handy for streaming tools and data pipelines
+- **Export as XML** - The same view as an XML document, one `<row>` element per row and one child element per column. Column headers become element names, with anything that is not legal in an XML name (spaces, punctuation, a leading digit) replaced so the output always parses. Cell text is written exactly as it reads, with `&`, `<` and `>` escaped.
 - **Export as Markdown table** - The same view as a GitHub-flavored Markdown table, ready to paste into a README, issue or pull request
 
 ### Delimiter

--- a/src/csvEditorProvider.ts
+++ b/src/csvEditorProvider.ts
@@ -255,7 +255,7 @@ export class CsvEditorProvider implements vscode.CustomEditorProvider<CsvDocumen
 
             // F4: Export handler — the webview sends the converted text plus a
             // suggested filename; the extension picks dialog filters from its
-            // extension (.json / .jsonl / .md).
+            // extension (.json / .jsonl / .xml / .md).
             } else if (msg.type === 'export') {
                 const filename   = msg.filename ?? 'export.json';
                 const defaultUri = vscode.Uri.file(
@@ -264,6 +264,7 @@ export class CsvEditorProvider implements vscode.CustomEditorProvider<CsvDocumen
                 const ext = path.extname(filename).toLowerCase();
                 const filters: Record<string, string[]> =
                     ext === '.jsonl' ? { 'JSON Lines': ['jsonl', 'ndjson'] } :
+                    ext === '.xml'   ? { 'XML':        ['xml'] } :
                     ext === '.md'    ? { 'Markdown':   ['md'] } :
                                        { 'JSON':       ['json'] };
                 filters['All files'] = ['*'];

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -124,7 +124,7 @@ export function getWebviewContent(
         <button id="btn-go-to-row"     title="Go to row (${mod}G)${isChunked ? ' — disabled in Paged View' : ''}"${isChunked ? ' disabled' : ''}><i class="codicon codicon-list-ordered"></i></button>
         <button id="btn-duplicates"    title="Find duplicate rows${isChunked ? ' — disabled in Paged View' : ''}"${isChunked ? ' disabled' : ''}><i class="codicon codicon-files"></i></button>
         <div    class="separator"></div>
-        <button id="btn-export"        title="Export as JSON, JSON Lines or Markdown" class="text-btn"${isPreview ? ' style="display:none;"' : ''}><i class="codicon codicon-export"></i> Export</button>
+        <button id="btn-export"        title="Export as JSON, JSON Lines, XML or Markdown" class="text-btn"${isPreview ? ' style="display:none;"' : ''}><i class="codicon codicon-export"></i> Export</button>
         <div    class="separator"></div>
         <span   id="delim-badge" class="delim-badge" title="Click to change delimiter">Delim: ,</span>
         <span   class="info" id="info"></span>
@@ -142,6 +142,7 @@ export function getWebviewContent(
     <div id="export-dropdown" class="delim-dropdown hidden">
         <div class="export-option" data-format="json">JSON</div>
         <div class="export-option" data-format="jsonl">JSON Lines</div>
+        <div class="export-option" data-format="xml">XML</div>
         <div class="export-option" data-format="md">Markdown table</div>
     </div>
 

--- a/src/webview/features/export.ts
+++ b/src/webview/features/export.ts
@@ -1,23 +1,24 @@
 import { state } from '../state';
 import type { ColType } from '../types';
-import { toJson, toJsonLines, toMarkdownTable } from '../utils/export-formats';
+import { toJson, toJsonLines, toMarkdownTable, toXml } from '../utils/export-formats';
 import { closeAllPopups } from './popups';
 
 // ── Export menu ──────────────────────────────────────────────────────────────
-// The toolbar Export button opens a small dropdown (JSON / JSON Lines /
-// Markdown table). Every format exports the CURRENT VIEW: active filters and
-// sort order are applied, columns appear in their current (possibly reordered)
+// The toolbar Export button opens a small dropdown (JSON / JSON Lines / XML /
+// Markdown table). Every format exports the CURRENT VIEW: active filters
+// and sort order are applied, columns appear in their current (possibly reordered)
 // order with their current (possibly renamed) headers. Hidden columns are
 // EXCLUDED, matching the Excel-style copy behavior — export reflects exactly the
 // visible view. A frozen reference row is exported first, matching where the
 // user sees it.
 // Saving the file itself already writes CSV, so there is no CSV entry here.
 
-type ExportFormat = 'json' | 'jsonl' | 'md';
+type ExportFormat = 'json' | 'jsonl' | 'xml' | 'md';
 
 const FORMAT_EXT: Record<ExportFormat, string> = {
     json: '.json',
     jsonl: '.jsonl',
+    xml: '.xml',
     md: '.md',
 };
 
@@ -56,6 +57,7 @@ function runExport(format: ExportFormat): void {
     let text: string;
     if (format === 'json')       text = toJson(headers, rows, types);
     else if (format === 'jsonl') text = toJsonLines(headers, rows, types);
+    else if (format === 'xml')   text = toXml(headers, rows, types);
     else                         text = toMarkdownTable(headers, rows, types);
 
     const base = FILENAME ? FILENAME.replace(/\.[^.]+$/, '') : 'export';

--- a/src/webview/utils/export-formats.ts
+++ b/src/webview/utils/export-formats.ts
@@ -2,9 +2,10 @@ import type { ColType } from '../types';
 
 // ── Export format converters ─────────────────────────────────────────────────
 // Pure string-matrix → text converters behind the toolbar Export menu (JSON,
-// JSON Lines, Markdown table). Kept free of DOM/grid access so they are unit-
-// testable in plain Node (see test/export-formats.test.cjs); features/export.ts
-// gathers the current grid view (filter/sort applied) and feeds it in here.
+// JSON Lines, Markdown table, XML). Kept free of DOM/grid access so they are
+// unit-testable in plain Node (see test/export-formats.test.cjs);
+// features/export.ts gathers the current grid view (filter/sort applied) and
+// feeds it in here.
 
 // JSON object keys come from the header row, which the user can rename or leave
 // blank — keys must still be non-empty and unique or rows would silently lose
@@ -100,5 +101,95 @@ export function toMarkdownTable(headers: string[], rows: string[][], types: ColT
         for (let c = 0; c < numCols; c++) cells.push(row[c] ?? '');
         out.push(line(cells));
     }
+    return out.join('\n') + '\n';
+}
+
+// ── XML ──────────────────────────────────────────────────────────────────────
+
+// XML element names are far stricter than JSON keys: a header like "Total (€)"
+// or "1st year" is not a legal name, so every character outside the XML Name
+// production is replaced with '_' and a name that cannot start a Name gets an
+// '_' prefix. Letters and digits are matched by Unicode class, so non-ASCII
+// headers ("Họ tên", "Größe") stay readable instead of collapsing into '______'.
+const XML_NAME_START = /[:_\p{L}]/u;
+const XML_NAME_CHAR  = /[-.:_\p{L}\p{N}\p{M}]/u;
+
+function sanitizeXmlName(raw: string, index: number): string {
+    const trimmed = (raw ?? '').trim();
+    let name = '';
+    for (const ch of trimmed) name += XML_NAME_CHAR.test(ch) ? ch : '_';
+    if (name === '') return `column_${index + 1}`;
+    // A name may not start with a digit, '-' or '.', and any name beginning
+    // with "xml" is reserved by the spec — an underscore fixes both without
+    // throwing away the header text.
+    if (!XML_NAME_START.test(name[0]) || /^xml/i.test(name)) name = '_' + name;
+    return name;
+}
+
+// Sanitizing can collapse two distinct headers onto one name ("a b" and "a-b"
+// both become "a_b"), so uniqueness is applied AFTER sanitizing — otherwise two
+// columns would share an element name and a reader could not tell them apart.
+export function xmlTagNames(headers: string[]): string[] {
+    const used = new Set<string>();
+    return headers.map((h, i) => {
+        const base = sanitizeXmlName(h, i);
+        let name = base;
+        for (let n = 2; used.has(name); n++) name = `${base}_${n}`;
+        used.add(name);
+        return name;
+    });
+}
+
+// The XML 1.0 Char production: tab/LF/CR plus the printable ranges, with the
+// surrogate block and the two non-characters at the end of the BMP excluded.
+function isXmlChar(cp: number): boolean {
+    return cp === 0x09 || cp === 0x0a || cp === 0x0d
+        || (cp >= 0x20    && cp <= 0xd7ff)
+        || (cp >= 0xe000  && cp <= 0xfffd)
+        || (cp >= 0x10000 && cp <= 0x10ffff);
+}
+
+// Characters outside that production (stray C0 control bytes, lone surrogates)
+// cannot appear in a document at all — not even as a numeric character
+// reference — so they are dropped rather than escaped.
+function stripInvalidXmlChars(value: string): string {
+    let out = '';
+    // Iterating by code point keeps astral characters (emoji, rare CJK) intact;
+    // a lone surrogate arrives on its own and fails isXmlChar, so it is dropped.
+    for (const ch of value) if (isXmlChar(ch.codePointAt(0)!)) out += ch;
+    return out;
+}
+
+// CR is escaped because a parser would otherwise normalise it to LF and
+// silently change the value; LF and tab are left as-is so multi-line cells stay
+// readable.
+export function escapeXmlText(value: string): string {
+    return stripInvalidXmlChars(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/\r/g, '&#13;');
+}
+
+// XML — one <row> element per row, one child element per column, 2-space
+// indented like the JSON output. Cell text is written verbatim (XML has no
+// number type, so coercing "2.50" into 2.5 would only lose formatting); the
+// column type is used solely to decide emptiness: an empty cell in a typed
+// column is the counterpart of JSON's null and becomes a self-closing <age/>,
+// while an empty cell in a string column stays an empty <name></name>.
+export function toXml(headers: string[], rows: string[][], types: ColType[]): string {
+    const tags = xmlTagNames(headers);
+    const out = ['<?xml version="1.0" encoding="UTF-8"?>', '<rows>'];
+    for (const row of rows) {
+        out.push('  <row>');
+        for (let c = 0; c < tags.length; c++) {
+            const raw  = row[c] ?? '';
+            const type = types[c] ?? 'string';
+            if (raw.trim() === '' && type !== 'string') out.push(`    <${tags[c]}/>`);
+            else out.push(`    <${tags[c]}>${escapeXmlText(raw)}</${tags[c]}>`);
+        }
+        out.push('  </row>');
+    }
+    out.push('</rows>');
     return out.join('\n') + '\n';
 }

--- a/test/export-formats.test.cjs
+++ b/test/export-formats.test.cjs
@@ -1,9 +1,10 @@
 // Tests for the export format converters (webview/utils/export-formats.ts):
-// JSON / JSON Lines / Markdown table generation from the grid's string matrix.
-// The risky parts are key derivation (blank and duplicate headers must not
-// silently drop fields) and value coercion (numbers/booleans should be typed
+// JSON / JSON Lines / Markdown table / XML generation from the grid's string
+// matrix. The risky parts are key derivation (blank and duplicate headers must
+// not silently drop fields), value coercion (numbers/booleans should be typed
 // in JSON, but NEVER lossily — "007" IDs, huge integers and stray text inside
-// a numeric column must survive as strings).
+// a numeric column must survive as strings) and XML well-formedness (arbitrary
+// header text has to become a legal element name, cell text has to be escaped).
 //
 // Run after `npm run compile` (or `tsc -p ./`):  node test/export-formats.test.cjs
 
@@ -14,6 +15,9 @@ const {
     toJson,
     toJsonLines,
     toMarkdownTable,
+    xmlTagNames,
+    escapeXmlText,
+    toXml,
 } = require('../out/webview/utils/export-formats.js');
 
 let failures = 0;
@@ -147,6 +151,104 @@ test('toMarkdownTable escapes pipes and converts newlines to <br>', () => {
 test('toMarkdownTable pads short rows so the table stays rectangular', () => {
     const out = toMarkdownTable(['a', 'b'], [['x']], ['string', 'string']);
     assert.strictEqual(out.split('\n')[2], '| x |  |');
+});
+
+// ── xmlTagNames ──────────────────────────────────────────────────────────────
+
+test('clean headers become element names unchanged', () => {
+    assert.deepStrictEqual(xmlTagNames(['name', 'city_2']), ['name', 'city_2']);
+});
+
+test('characters illegal in an XML name become underscores', () => {
+    assert.deepStrictEqual(xmlTagNames(['Total (€)', 'first name']), ['Total____', 'first_name']);
+});
+
+test('names that cannot start an XML name get an underscore prefix', () => {
+    assert.deepStrictEqual(xmlTagNames(['1st year', '-lead', '.dot']), ['_1st_year', '_-lead', '_.dot']);
+});
+
+test('the reserved "xml" prefix is escaped', () => {
+    assert.deepStrictEqual(xmlTagNames(['xmlns', 'XmlId']), ['_xmlns', '_XmlId']);
+});
+
+test('blank headers become positional column_N element names', () => {
+    assert.deepStrictEqual(xmlTagNames(['a', '', '  ']), ['a', 'column_2', 'column_3']);
+});
+
+test('non-ASCII letters survive as element names', () => {
+    assert.deepStrictEqual(xmlTagNames(['Größe', 'Họ tên']), ['Größe', 'Họ_tên']);
+});
+
+test('headers that sanitize onto the same name are still made unique', () => {
+    assert.deepStrictEqual(xmlTagNames(['a b', 'a-b', 'a b']), ['a_b', 'a-b', 'a_b_2']);
+});
+
+// ── escapeXmlText ────────────────────────────────────────────────────────────
+
+test('markup characters are escaped', () => {
+    assert.strictEqual(escapeXmlText('a & b <tag> "q" \'s\''), 'a &amp; b &lt;tag&gt; "q" \'s\'');
+});
+
+test('an already-escaped entity is not double-decoded, only re-escaped', () => {
+    assert.strictEqual(escapeXmlText('&amp;'), '&amp;amp;');
+});
+
+test('CR is escaped so parsers do not normalise it away, LF and tab stay literal', () => {
+    assert.strictEqual(escapeXmlText('a\r\nb\tc'), 'a&#13;\nb\tc');
+});
+
+test('control characters illegal in XML 1.0 are dropped', () => {
+    const raw = 'a' + String.fromCharCode(0) + 'b' + String.fromCharCode(0x1f) + 'c';
+    assert.strictEqual(escapeXmlText(raw), 'abc');
+});
+
+test('astral characters (emoji) survive intact', () => {
+    assert.strictEqual(escapeXmlText('ok 👍'), 'ok 👍');
+});
+
+test('a lone surrogate is dropped instead of producing invalid XML', () => {
+    assert.strictEqual(escapeXmlText('a' + String.fromCharCode(0xd800) + 'b'), 'ab');
+});
+
+// ── toXml ────────────────────────────────────────────────────────────────────
+
+test('toXml wraps rows in a declaration and a <rows> root', () => {
+    const out = toXml(['name', 'age'], [['Alice', '30']], ['string', 'integer']);
+    assert.strictEqual(out,
+        '<?xml version="1.0" encoding="UTF-8"?>\n' +
+        '<rows>\n' +
+        '  <row>\n' +
+        '    <name>Alice</name>\n' +
+        '    <age>30</age>\n' +
+        '  </row>\n' +
+        '</rows>\n');
+});
+
+test('toXml on an empty row set still emits a well-formed root', () => {
+    const out = toXml(['a'], [], ['string']);
+    assert.strictEqual(out, '<?xml version="1.0" encoding="UTF-8"?>\n<rows>\n</rows>\n');
+});
+
+test('toXml writes numbers verbatim — no coercion, so "2.50" and "007" keep their text', () => {
+    const out = toXml(['f', 'id'], [['2.50', '007']], ['float', 'integer']);
+    assert.ok(out.indexOf('<f>2.50</f>') >= 0, 'trailing zero kept');
+    assert.ok(out.indexOf('<id>007</id>') >= 0, 'leading zero kept');
+});
+
+test('toXml: an empty cell is self-closing in a typed column, empty text in a string column', () => {
+    const out = toXml(['age', 'note'], [['', '']], ['integer', 'string']);
+    assert.ok(out.indexOf('    <age/>\n') >= 0, 'typed empty cell is self-closing');
+    assert.ok(out.indexOf('    <note></note>\n') >= 0, 'string empty cell stays an empty element');
+});
+
+test('toXml escapes cell content instead of emitting raw markup', () => {
+    const out = toXml(['a'], [['<b>&</b>']], ['string']);
+    assert.ok(out.indexOf('<a>&lt;b&gt;&amp;&lt;/b&gt;</a>') >= 0);
+});
+
+test('toXml pads short rows so every row has the same elements', () => {
+    const out = toXml(['a', 'b'], [['x']], ['string', 'string']);
+    assert.ok(out.indexOf('<b></b>') >= 0);
 });
 
 if (failures) { console.error('\n' + failures + ' test(s) failed'); process.exit(1); }


### PR DESCRIPTION
Adds XML as a fourth export format. Filters, sort and column order applied.

<img width="202" height="150" alt="image" src="https://github.com/user-attachments/assets/e1a3479e-feb6-4887-9b12-92482c58f1b6" />

- Element names are stricter than JSON keys, so uniqueKeys is not reused. Illegal characters become `_`, a name starting with a digit, `-`, `.` or the reserved xml prefix gets a leading `_`, and uniquing runs after sanitizing since `a b` and `a-b` both collapse to `a_b`.
- No coercion. XML has no number type, so cell text is verbatim; the column type only decides emptiness - `<qty/>` for an empty typed cell, `<note></note>` for an empty text one.
- Escaping. `&`, `<`, `>` escaped, `\r` becomes `&#13;` (a parser would normalise it to `\n` and change the value), and characters illegal in XML 1.0 are dropped since they cannot be represented at all.