### PR TITLE
Zoom the grid only, not the toolbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For files larger than 10 MB you get a quick menu to open the full file, preview 
 - **Sort & Filter** - Click any column header to sort. Use the filter icon to search within a column. Active filters show in the toolbar with a one-click clear button.
 - **Auto-Fit Columns** - Fit all columns to their content with one click. Double-click a resize handle to auto-fit a single column.
 - **Column Resize** - Drag column borders to adjust width manually
-- **Zoom** - Scale the whole grid from 60% to 200% with the toolbar buttons or keyboard shortcuts. The zoom level shows in the toolbar.
+- **Zoom** - Scale the grid from 60% to 200% with the toolbar buttons or keyboard shortcuts. The zoom level shows in the toolbar.
 - **Theme Integration** - Automatically adapts to your VS Code color theme (dark or light)
 
 ![CSV Grid Editor toolbar with auto-fit, zoom, find and replace, export and column profile buttons](https://raw.githubusercontent.com/Robin-Reiche/csv-grid-editor/master/images/toolbar.png)

--- a/media/webview.css
+++ b/media/webview.css
@@ -43,6 +43,10 @@ button .codicon {
     line-height: 1;
 }
 
+/* The Clear-filters button reads as a label with an icon rather than an icon
+   button, so it sits at label size instead of the 14px icon size above. */
+#btn-clear-filters { font-size: 11px; }
+
 .toolbar button .filter-clear-label {
     font-size: 11px;
     font-weight: 400;
@@ -103,6 +107,8 @@ button .codicon {
 /* ── Profile panel ── */
 #profile-panel {
     width: 295px;
+    /* Everything inside the panel is sized in em against this base. */
+    font-size: 12px;
     flex-shrink: 0;
     display: none;
     flex-direction: column;

--- a/src/webview/features/zoom.ts
+++ b/src/webview/features/zoom.ts
@@ -1,18 +1,17 @@
 import { state } from '../state';
 
+// ── Zoom ─────────────────────────────────────────────────────────────────────
+// Zoom scales the DATA only — row height, header height, cell font and cell
+// padding — the way the editor's own font-size zoom does. The chrome around the
+// grid (toolbar, footer, profile panel) keeps its size at every zoom level.
+// Scaling the toolbar too was not just visually wrong: every step re-laid out
+// the toolbar, so the zoom buttons slid out from under the pointer and a second
+// click landed on a neighbouring button.
+
 const BASE_ROW_HEIGHT     = 24;
 const BASE_HEADER_HEIGHT  = 26;
 const BASE_FONT_SIZE      = 13;
 const BASE_CELL_PADDING   = 6;
-const BASE_TOOLBAR_HEIGHT = 28;
-const BASE_TOOLBAR_FONT   = 14;
-const BASE_TOOLBAR_PAD    = 5;
-const BASE_SEP_HEIGHT     = 14;
-const BASE_INFO_FONT      = 11;
-const BASE_FOOTER_HEIGHT  = 22;
-const BASE_FOOTER_FONT    = 11;
-const BASE_TEXT_BTN_FONT  = 11;
-const BASE_PROFILE_FONT   = 12;
 
 export function applyZoom(): void {
     const pct   = state.ZOOM_STEPS[state.zoomIndex];
@@ -24,36 +23,10 @@ export function applyZoom(): void {
     container.style.setProperty('--ag-font-size',                Math.round(BASE_FONT_SIZE     * scale) + 'px');
     container.style.setProperty('--ag-cell-horizontal-padding',  Math.round(BASE_CELL_PADDING  * scale) + 'px');
 
-    const toolbar = document.querySelector<HTMLElement>('.toolbar')!;
-    toolbar.style.height   = Math.round(BASE_TOOLBAR_HEIGHT * scale) + 'px';
-    toolbar.style.fontSize = Math.round(BASE_TOOLBAR_FONT   * scale) + 'px';
-
-    toolbar.querySelectorAll<HTMLButtonElement>('button').forEach(btn => {
-        btn.style.fontSize = Math.round(BASE_TOOLBAR_FONT * scale) + 'px';
-        btn.style.padding  = '2px ' + Math.round(BASE_TOOLBAR_PAD * scale) + 'px';
-    });
-
-    const clearBtn = document.getElementById('btn-clear-filters');
-    if (clearBtn) clearBtn.style.fontSize = Math.round(BASE_TEXT_BTN_FONT * scale) + 'px';
-
-    toolbar.querySelectorAll<HTMLElement>('.separator').forEach(sep => {
-        sep.style.height = Math.round(BASE_SEP_HEIGHT * scale) + 'px';
-    });
-
-    const info      = document.getElementById('info');
+    // Only the text changes — the label keeps its fixed font-size and min-width,
+    // so "60%" → "100%" cannot nudge the zoom-in button sideways either.
     const zoomLabel = document.getElementById('zoom-level');
-    if (info)      info.style.fontSize      = Math.round(BASE_INFO_FONT   * scale) + 'px';
-    if (zoomLabel) zoomLabel.style.fontSize = Math.round(BASE_INFO_FONT   * scale) + 'px';
-    if (zoomLabel) zoomLabel.textContent    = pct + '%';
-
-    const footer = document.querySelector<HTMLElement>('.footer');
-    if (footer) {
-        footer.style.height   = Math.round(BASE_FOOTER_HEIGHT * scale) + 'px';
-        footer.style.fontSize = Math.round(BASE_FOOTER_FONT   * scale) + 'px';
-    }
-
-    const profilePanel = document.getElementById('profile-panel');
-    if (profilePanel) profilePanel.style.fontSize = Math.round(BASE_PROFILE_FONT * scale) + 'px';
+    if (zoomLabel) zoomLabel.textContent = pct + '%';
 
     state.autoFitCache = null;
 

--- a/src/webview/grid/builder.ts
+++ b/src/webview/grid/builder.ts
@@ -192,9 +192,6 @@ export function buildGrid(): void {
     container.innerHTML = '';
     applyGridTheme(); // ensure correct ag-theme-alpine[-dark] class
 
-    const ZOOM_SCALE = state.ZOOM_STEPS[state.zoomIndex] / 100;
-    const BASE_TEXT_BTN_FONT = 11;
-
     // Merge find-match highlight rules with duplicate-row highlight.
     // Both rule sets must coexist on the same defaultColDef.
     const cellClassRules = {
@@ -320,10 +317,7 @@ export function buildGrid(): void {
             const isAnyFilter = state.gridApi?.isAnyFilterPresent();
             const cfBtn = document.getElementById('btn-clear-filters') as HTMLButtonElement | null;
             const sepBtn = document.getElementById('sep-filters') as HTMLElement | null;
-            if (cfBtn) {
-                cfBtn.style.display  = isAnyFilter ? '' : 'none';
-                cfBtn.style.fontSize = Math.round(BASE_TEXT_BTN_FONT * ZOOM_SCALE) + 'px';
-            }
+            if (cfBtn) cfBtn.style.display = isAnyFilter ? '' : 'none';
             if (sepBtn) sepBtn.style.display = isAnyFilter ? '' : 'none';
 
             updateCountsDisplay();


### PR DESCRIPTION
Zooming scaled the toolbar, footer and profile panel along with the grid. Worse than cosmetic: every step re-laid out the toolbar - the percentage label alone went from 11px to 22px - so the zoom buttons slid sideways and a second click landed on the neighbouring button. Zooming twice in a row was a coin flip.

`applyZoom()` now sets only the four grid variables (row height, header height, cell font, cell padding) plus the label text. The chrome keeps its size at every zoom level, the way the editor's own font-size zoom behaves.

Two sizes JavaScript used to compute moved into CSS so the 100% view is unchanged: the Clear-filters button (11px) and the profile panel base font (12px, which everything inside it sizes against in `em`).

Before
<img width="1164" height="544" alt="image" src="https://github.com/user-attachments/assets/3c03fdf5-48d2-4ae3-ac92-7dc153129e46" />

After
<img width="946" height="526" alt="image" src="https://github.com/user-attachments/assets/79b90e3d-99c0-4420-9776-3848fcfccb68" />
