### PR TITLE
Add Copy as CSV and Copy as CSV with header to the range context menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ For files larger than 10 MB you get a quick menu to open the full file, preview 
   - `Shift+click` and `Shift`+arrow keys extend the selection, `Ctrl+A` selects everything
   - `Ctrl+C` copies the selection as tab-separated values (TSV) that paste straight into Excel or Google Sheets
   - Right-click → **Copy with header** to include the column headers in the copy
+  - Right-click → **Copy as CSV** or **Copy as CSV with header** puts the same selection on the clipboard comma-separated, ready to paste into a CSV file, a code snippet or an issue. Values holding a comma, a quote or a line break are quoted, so the block reads back as exactly the cells you copied.
   - `Delete` / `Backspace` clears every cell in the selection
   - The status bar shows the selection size plus live `Count / Sum / Avg / Min / Max`
 - **Export as JSON** - Convert the current filtered and sorted view to a JSON array of objects via the native VS Code save dialog. Column headers become the keys and numbers and booleans come out typed, while values that would lose information (IDs with leading zeros, very large numbers) stay strings. Columns you have hidden in the column chooser are left out, the same as copy.
@@ -232,7 +233,7 @@ Install CSV Grid Editor and open any `.csv` or `.tsv` file. It opens straight in
 Double-click any cell to edit it inline, then save with `Ctrl+S`. Changes are written back to the file and you can undo with `Ctrl+Z`. You never have to leave the editor or open a spreadsheet app.
 
 ### Can I copy and paste between this grid and Excel or Google Sheets?
-Yes. Select a range with click and drag, press `Ctrl+C`, and the cells are copied as tab-separated values that paste cleanly into Excel or Google Sheets. Right-click then **Copy with header** to include the column names.
+Yes. Select a range with click and drag, press `Ctrl+C`, and the cells are copied as tab-separated values that paste cleanly into Excel or Google Sheets. Right-click then **Copy with header** to include the column names, or **Copy as CSV** if you need the selection comma-separated instead.
 
 ### Does it work with semicolon, tab or pipe delimited files?
 Yes. The delimiter is auto-detected on open (comma, semicolon, tab), and `.tsv` files always use tab. You can also switch the delimiter by hand from the toolbar to comma, semicolon, tab or pipe.

--- a/src/webview/features/delete-row-col.ts
+++ b/src/webview/features/delete-row-col.ts
@@ -253,14 +253,23 @@ function showContextMenu(x: number, y: number, rowIndex: number | null, colId: s
 
     // ── Copy ──────────────────────────────────────────────────────────────────
     if (hasMultiSelection()) {
-        // A range is selected — offer range copy, with and without header row.
-        const copyRange = makeRowItem('Copy', 'codicon-copy');
-        copyRange.addEventListener('click', () => { copySelection(false); hideMenu(); });
-        menu.appendChild(copyRange);
-
-        const copyWithHeader = makeRowItem('Copy with header', 'codicon-copy');
-        copyWithHeader.addEventListener('click', () => { copySelection(true); hideMenu(); });
-        menu.appendChild(copyWithHeader);
+        // A range is selected - offer range copy, with and without header row, in
+        // each of the two clipboard formats. Copy is tab-separated (what Excel and
+        // Google Sheets paste back as columns, and what Ctrl+C gives); Copy as CSV
+        // is comma-separated for pasting into a file, a snippet or a ticket. The
+        // format is named in the label rather than hidden behind a remembered
+        // setting, so what lands on the clipboard is never a surprise.
+        const copyVariants: Array<[string, boolean, 'tsv' | 'csv']> = [
+            ['Copy',                    false, 'tsv'],
+            ['Copy with header',        true,  'tsv'],
+            ['Copy as CSV',             false, 'csv'],
+            ['Copy as CSV with header', true,  'csv'],
+        ];
+        for (const [label, withHeader, format] of copyVariants) {
+            const item = makeRowItem(label, 'codicon-copy');
+            item.addEventListener('click', () => { copySelection(withHeader, format); hideMenu(); });
+            menu.appendChild(item);
+        }
 
         const sep = document.createElement('div');
         sep.className = 'col-ctx-separator';

--- a/src/webview/features/range-select.ts
+++ b/src/webview/features/range-select.ts
@@ -1,7 +1,8 @@
 import { state } from '../state';
 import { pushUndo, notifyChange } from './undo-redo';
 import { recomputeColTypes } from '../grid/column-type';
-import { tsvCell } from '../utils/csv';
+import { toClipboardBlock } from '../utils/csv';
+import type { ClipboardFormat } from '../utils/csv';
 import { closeAllPopups } from './popups';
 
 // ── Excel-style range selection for the main grid ─────────────────────────────
@@ -188,30 +189,30 @@ export function hasMultiSelection(): boolean {
     return selActive && selCellCount > 1;
 }
 
-export function copySelection(withHeader = false): void {
+// Copy the current selection. The format is the caller's choice - Ctrl+C and the
+// plain "Copy" item stay on TSV so the block pastes into Excel and Google Sheets
+// as columns; the "Copy as CSV" items ask for CSV explicitly. Quoting for both
+// lives in toClipboardBlock().
+export function copySelection(withHeader = false, format: ClipboardFormat = 'tsv'): void {
     if (!state.gridApi || !selActive) return;
     const cols = displayedColIds();
     const selCols = cols.filter(id => selColIds.has(id));
     const rowMap = displayRowToOrig();
 
-    const lines: string[] = [];
+    const rows: string[][] = [];
     if (withHeader) {
         const header = state.data[0] ?? [];
-        lines.push(selCols.map(colId => {
-            const ci = parseInt(colId.slice(4), 10);
-            return tsvCell(String(header[ci] ?? ''));
-        }).join('\t'));
+        rows.push(selCols.map(colId => String(header[parseInt(colId.slice(4), 10)] ?? '')));
     }
     for (let r = selRowLo; r <= selRowHi; r++) {
         const orig = rowMap[r];
         const dataRow = orig != null && orig >= 0 ? state.data[orig] : undefined;
-        lines.push(selCols.map(colId => {
-            const ci = parseInt(colId.slice(4), 10);
-            const v = dataRow?.[ci];
-            return tsvCell(v != null ? String(v) : '');
-        }).join('\t'));
+        rows.push(selCols.map(colId => {
+            const v = dataRow?.[parseInt(colId.slice(4), 10)];
+            return v != null ? String(v) : '';
+        }));
     }
-    writeClipboard(lines.join('\n'));
+    writeClipboard(toClipboardBlock(rows, format));
 }
 
 // ── delete (clear cells) ──────────────────────────────────────────────────────

--- a/src/webview/utils/csv.ts
+++ b/src/webview/utils/csv.ts
@@ -69,6 +69,25 @@ export function tsvCell(value: string): string {
     return value;
 }
 
+// The clipboard formats a selection can be copied in.
+export type ClipboardFormat = 'tsv' | 'csv';
+
+// Serialize a rectangular block of cells for the clipboard.
+//
+// TSV stays the default (Ctrl+C, the plain "Copy" item): tabs are what Excel and
+// Google Sheets read back as columns, and pasting a comma-separated block into
+// them lands the whole row in one cell. CSV is the explicit choice, offered as
+// its own context-menu item for pasting into anything that expects a real CSV -
+// a file, a code snippet, a ticket. It is always comma-separated regardless of
+// the delimiter the open file uses, because that is what the label promises.
+//
+// Both quote per RFC 4180, so a value carrying the separator, a double quote or
+// a line break survives the round trip.
+export function toClipboardBlock(rows: CsvRow[], format: ClipboardFormat): string {
+    if (format === 'csv') return toCsv(rows, ',');
+    return rows.map(row => row.map(cell => tsvCell(String(cell))).join('\t')).join('\n');
+}
+
 // A wrapped multi-line cell is only as wide as its longest LINE, not as wide as
 // the whole value — auto-fit would otherwise size the column to every line laid
 // end to end (features/auto-fit.ts). Longest is taken by character count, which

--- a/test/copy-formats.test.cjs
+++ b/test/copy-formats.test.cjs
@@ -1,0 +1,108 @@
+// Tests for the clipboard serializer behind the range-copy context menu
+// (webview/utils/csv.ts toClipboardBlock). Copy stays tab-separated so a block
+// pastes into Excel and Google Sheets as columns; Copy as CSV is comma-separated
+// for pasting into a real CSV. The risky part is quoting: each format has to
+// quote the values that would otherwise break ITS separator - a comma is
+// harmless in TSV and fatal in CSV, a tab the other way round - and both have to
+// keep embedded quotes and line breaks intact so the block parses back to the
+// cells it came from.
+//
+// Run after `npm run compile` (or `tsc -p ./`):  node test/copy-formats.test.cjs
+
+const assert = require('assert');
+const { toClipboardBlock, parseCsv } = require('../out/webview/utils/csv.js');
+
+let failures = 0;
+function test(name, fn) {
+    try { fn(); console.log('  ✓ ' + name); }
+    catch (e) { failures++; console.error('  ✗ ' + name + '\n      ' + e.message); }
+}
+
+console.log('clipboard copy formats');
+
+// ── plain values ─────────────────────────────────────────────────────────────
+
+test('tsv joins cells with tabs and rows with newlines', () => {
+    assert.strictEqual(
+        toClipboardBlock([['a', 'b'], ['c', 'd']], 'tsv'),
+        'a\tb\nc\td'
+    );
+});
+
+test('csv joins cells with commas and rows with newlines', () => {
+    assert.strictEqual(
+        toClipboardBlock([['a', 'b'], ['c', 'd']], 'csv'),
+        'a,b\nc,d'
+    );
+});
+
+test('plain values are never quoted in either format', () => {
+    const rows = [['Month', 'Average'], ['Aug', '0.7']];
+    assert.strictEqual(toClipboardBlock(rows, 'tsv'), 'Month\tAverage\nAug\t0.7');
+    assert.strictEqual(toClipboardBlock(rows, 'csv'), 'Month,Average\nAug,0.7');
+});
+
+// ── quoting is per format ────────────────────────────────────────────────────
+
+test('a comma is quoted in csv and left alone in tsv', () => {
+    const rows = [['Hanoi, VN', 'x']];
+    assert.strictEqual(toClipboardBlock(rows, 'csv'), '"Hanoi, VN",x');
+    assert.strictEqual(toClipboardBlock(rows, 'tsv'), 'Hanoi, VN\tx');
+});
+
+test('a tab is quoted in tsv and left alone in csv', () => {
+    const rows = [['a\tb', 'x']];
+    assert.strictEqual(toClipboardBlock(rows, 'tsv'), '"a\tb"\tx');
+    assert.strictEqual(toClipboardBlock(rows, 'csv'), 'a\tb,x');
+});
+
+test('embedded double quotes are doubled in both formats', () => {
+    const rows = [['say "hi"']];
+    assert.strictEqual(toClipboardBlock(rows, 'tsv'), '"say ""hi"""');
+    assert.strictEqual(toClipboardBlock(rows, 'csv'), '"say ""hi"""');
+});
+
+test('a line break inside a cell is quoted in both formats', () => {
+    const rows = [['line1\nline2', 'x']];
+    assert.strictEqual(toClipboardBlock(rows, 'tsv'), '"line1\nline2"\tx');
+    assert.strictEqual(toClipboardBlock(rows, 'csv'), '"line1\nline2",x');
+});
+
+test('empty cells stay empty rather than becoming quotes', () => {
+    assert.strictEqual(toClipboardBlock([['a', '', 'c']], 'csv'), 'a,,c');
+    assert.strictEqual(toClipboardBlock([['a', '', 'c']], 'tsv'), 'a\t\tc');
+});
+
+// ── round trip ───────────────────────────────────────────────────────────────
+// What copy writes has to parse back to the exact cells it came from - that is
+// what makes the block usable in another CSV file and in this grid's own paste.
+
+test('a block with every awkward character round-trips through csv', () => {
+    const rows = [
+        ['name', 'note'],
+        ['Hanoi, VN', 'say "hi"'],
+        ['multi\nline', ''],
+    ];
+    assert.deepStrictEqual(parseCsv(toClipboardBlock(rows, 'csv'), ',', false), rows);
+});
+
+test('a block with every awkward character round-trips through tsv', () => {
+    const rows = [
+        ['name', 'note'],
+        ['Hanoi, VN', 'a\tb'],
+        ['multi\nline', 'say "hi"'],
+    ];
+    assert.deepStrictEqual(parseCsv(toClipboardBlock(rows, 'tsv'), '\t', false), rows);
+});
+
+// ── header row ───────────────────────────────────────────────────────────────
+// "Copy with header" simply prepends the header row before serializing, so the
+// header is quoted by the same rules as any other row.
+
+test('a header carrying the separator is quoted like any other row', () => {
+    const rows = [['first, last', 'age'], ['Lê Thị', '30']];
+    assert.strictEqual(toClipboardBlock(rows, 'csv'), '"first, last",age\nLê Thị,30');
+});
+
+console.log(failures === 0 ? '\nAll copy format tests passed.' : `\n${failures} test(s) failed.`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Adds Copy as CSV / Copy as CSV with header alongside the TSV items; `Ctrl+C` still gives TSV.

<img width="582" height="367" alt="image" src="https://github.com/user-attachments/assets/18fdd6fb-734b-468f-81c0-d92cc4e76cb4" />
