### PR TITLE
Keep the delete menu items red on hover instead of white on light themes

### DIFF
--- a/media/webview.css
+++ b/media/webview.css
@@ -1159,7 +1159,7 @@ body.vscode-high-contrast #grid-container.cm-on {
 .col-ctx-item:hover { background: var(--vscode-menu-selectionBackground, #094771); color: var(--vscode-menu-selectionForeground, #fff); }
 .col-ctx-separator { height: 1px; margin: 3px 0; background: var(--vscode-menu-border, #454545); pointer-events: none; }
 .col-ctx-item.danger { color: var(--vscode-errorForeground, #f48771); }
-.col-ctx-item.danger:hover { background: var(--vscode-inputValidation-errorBackground, #5a1d1d); color: #fff; }
+.col-ctx-item.danger:hover { background: var(--vscode-inputValidation-errorBackground, #5a1d1d); color: var(--vscode-errorForeground, #f48771); }
 .col-ctx-item .codicon { font-size: 16px; width: 16px; flex-shrink: 0; font-weight: normal; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
 
 /* ── Row Context Menu ── */
@@ -1177,12 +1177,12 @@ body.vscode-high-contrast #grid-container.cm-on {
 .row-ctx-item { display: flex; align-items: center; gap: 8px; padding: 5px 12px; font-size: 12px; cursor: pointer; color: var(--vscode-menu-foreground, #ccc); }
 .row-ctx-item:hover { background: var(--vscode-menu-selectionBackground, #094771); color: var(--vscode-menu-selectionForeground, #fff); }
 .row-ctx-item.danger { color: var(--vscode-errorForeground, #f48771); }
-.row-ctx-item.danger:hover { background: var(--vscode-inputValidation-errorBackground, #5a1d1d); color: #fff; }
+.row-ctx-item.danger:hover { background: var(--vscode-inputValidation-errorBackground, #5a1d1d); color: var(--vscode-errorForeground, #f48771); }
 .row-ctx-item .codicon { font-size: 16px; width: 16px; flex-shrink: 0; font-weight: normal; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
 
 /* AG Grid context menu danger items */
 .ag-menu-option.ctx-danger .ag-menu-option-text { color: var(--vscode-errorForeground, #f48771); }
-.ag-menu-option.ctx-danger:hover .ag-menu-option-text { color: #fff; }
+.ag-menu-option.ctx-danger:hover .ag-menu-option-text { color: var(--vscode-errorForeground, #f48771); }
 .ag-menu-option.ctx-danger:hover { background-color: var(--vscode-inputValidation-errorBackground, #5a1d1d) !important; }
 
 /* ── Find & Replace Bar ── */

--- a/test/danger-item-contrast.test.cjs
+++ b/test/danger-item-contrast.test.cjs
@@ -1,0 +1,80 @@
+// Guard for the hover colour of the destructive menu items (Delete row, Delete
+// column) in media/webview.css.
+//
+// These used to force `color: #fff` on hover on top of the themed error
+// background. That reads fine on a dark theme, where the background is a deep
+// red, and is close to invisible on a light one, where the same variable is a
+// pale pink - the item looked disabled exactly while you were pointing at it.
+// Since the extension is developed on dark themes, the regression is easy to
+// reintroduce and hard to notice, so the rule is asserted here: a danger item's
+// hover colour has to come from the theme, never from a literal.
+//
+// Run:  node test/danger-item-contrast.test.cjs
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+// Comments go first: they sit between rules, so the crude block matcher below
+// would otherwise read a comment as part of the following selector - and these
+// rules are commented with the very selectors being matched.
+const css = fs.readFileSync(path.join(__dirname, '..', 'media', 'webview.css'), 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+
+let failures = 0;
+function test(name, fn) {
+    try { fn(); console.log('  ✓ ' + name); }
+    catch (e) { failures++; console.error('  ✗ ' + name + '\n      ' + e.message); }
+}
+
+// Every rule block in the stylesheet, as { selector, body }.
+function rules() {
+    const out = [];
+    const re = /([^{}]+)\{([^{}]*)\}/g;
+    let m;
+    while ((m = re.exec(css)) !== null) {
+        out.push({ selector: m[1].trim().replace(/\s+/g, ' '), body: m[2] });
+    }
+    return out;
+}
+
+// The `color` declaration of a rule body, ignoring `background-color`.
+function colorOf(body) {
+    const m = /(?:^|[;{\s])color\s*:\s*([^;]+)/.exec(body);
+    return m ? m[1].trim() : null;
+}
+
+const dangerHover = rules().filter(r =>
+    /danger/.test(r.selector) && /:hover/.test(r.selector) && colorOf(r.body) !== null
+);
+
+console.log('danger menu item contrast');
+
+test('the danger hover rules are still in the stylesheet', () => {
+    // Three of them: the column header menu, the row/cell menu and the AG Grid
+    // menu. If a rename drops one, this test would otherwise pass vacuously.
+    assert.strictEqual(dangerHover.length, 3,
+        `expected 3 danger :hover rules with a colour, found ${dangerHover.length}: ` +
+        dangerHover.map(r => r.selector).join(' | '));
+});
+
+test('no danger item hard-codes its hover colour', () => {
+    for (const r of dangerHover) {
+        const color = colorOf(r.body);
+        assert.ok(!/^(#|rgb|hsl|white\b)/i.test(color),
+            `${r.selector} hard-codes "color: ${color}" - a literal cannot be legible ` +
+            'on both the dark and the light themed error background');
+    }
+});
+
+test('a danger item stays red on hover', () => {
+    for (const r of dangerHover) {
+        const color = colorOf(r.body);
+        assert.ok(color.includes('--vscode-errorForeground'),
+            `${r.selector} sets "color: ${color}" on hover - it should keep the error ` +
+            'foreground so the item still reads as destructive');
+    }
+});
+
+console.log(failures === 0 ? '\nAll danger item contrast tests passed.' : `\n${failures} test(s) failed.`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Hovering Delete row or Delete column forced `color: #fff` over the themed error background. That background is a deep red on dark themes but a pale pink on light ones, so the label all but vanished and the item read as disabled.

Hover now keeps `--vscode-errorForeground`, the colour VS Code pairs with that background in both themes.

Before
<img width="176" height="214" alt="image" src="https://github.com/user-attachments/assets/43d620e9-309e-4295-a7f2-86dedb2dc04c" />

After
<img width="158" height="205" alt="image" src="https://github.com/user-attachments/assets/c8b2b29f-33b9-4a6f-95d5-ae8d21fe3204" />

