### PR TITLE
Click the zoom percentage to go back to 100%

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For files larger than 10 MB you get a quick menu to open the full file, preview 
 - **Sort & Filter** - Click any column header to sort. Use the filter icon to search within a column. Active filters show in the toolbar with a one-click clear button.
 - **Auto-Fit Columns** - Fit all columns to their content with one click, measured across every row of the file and not just the ones on screen. Double-click a resize handle to auto-fit a single column.
 - **Column Resize** - Drag column borders to adjust width manually
-- **Zoom** - Scale the grid from 60% to 200% with the toolbar buttons or keyboard shortcuts. The zoom level shows in the toolbar.
+- **Zoom** - Scale the grid from 60% to 200% with the toolbar buttons or keyboard shortcuts. The zoom level shows in the toolbar, and clicking it takes you straight back to 100%.
 - **Control Characters** - Invisible control characters inside a value show as a small chip with the character's abbreviation instead of an unnamed box, so you can tell which one it is. Hover it for the full name. The value itself is untouched, so editing, copy and save still carry the original character.
 - **Multi-line cells** - A cell that holds a line break shows a small `↵` chip at every break, so you can see it is more than one line even though the row keeps its height. The toolbar's **Wrap cell text** button lets rows grow instead, so long values and line breaks are readable in full. The chip stays visible there too, which is what tells you whether a line ended because the value breaks or because it ran into the edge of the column. The setting is remembered across files and sessions.
 - **Theme Integration** - Automatically adapts to your VS Code color theme (dark or light)

--- a/media/webview.css
+++ b/media/webview.css
@@ -85,6 +85,32 @@ button .codicon {
     cursor: default;
 }
 
+/* The zoom percentage is also the reset control: click it to return to 100%.
+   The padding is there at every zoom level, not just while hovering, so the
+   hover background has room without the label growing and shoving the zoom
+   buttons sideways.
+
+   The width has to hold the widest label ("100%", "200%") including that
+   padding, or a three-character "80%" contracts the span and drags everything
+   to its right along with it every time you step past 100%. `flex: none` keeps
+   the toolbar from taking the width back when it runs short of room. */
+.zoom-level {
+    font-size: 11px;
+    flex: none;
+    min-width: 40px;
+    text-align: center;
+    opacity: 0.6;
+    padding: 2px 4px;
+    border-radius: 3px;
+}
+
+/* Only at a zoom other than 100%, where clicking actually does something. */
+.zoom-level.resettable { cursor: pointer; }
+.zoom-level.resettable:hover {
+    opacity: 1;
+    background: var(--vscode-toolbar-hoverBackground, rgba(255,255,255,0.1));
+}
+
 .toolbar .separator {
     width: 1px;
     height: 14px;

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -114,7 +114,7 @@ export function getWebviewContent(
         <button id="btn-clear-filters" title="Clear all filters" style="display:none;"><i class="codicon codicon-filter-filled"></i><span class="filter-clear-label">Clear</span></button>
         <div    class="separator" id="sep-filters" style="display:none;"></div>
         <button id="btn-zoom-out" title="Decrease size (${mod}-)"><i class="codicon codicon-zoom-out"></i></button>
-        <span   id="zoom-level"  style="font-size:11px;min-width:28px;text-align:center;opacity:0.6;">100%</span>
+        <span   id="zoom-level"  class="zoom-level">100%</span>
         <button id="btn-zoom-in"  title="Increase size (${mod}+)"><i class="codicon codicon-zoom-in"></i></button>
         <div    class="separator"></div>
         <button id="btn-profile"       title="Column Profile"><i class="codicon codicon-graph"></i></button>

--- a/src/webview/features/zoom.ts
+++ b/src/webview/features/zoom.ts
@@ -13,6 +13,14 @@ const BASE_HEADER_HEIGHT  = 26;
 const BASE_FONT_SIZE      = 13;
 const BASE_CELL_PADDING   = 6;
 
+// The step the percentage label resets to when clicked. Looked up rather than
+// hard-coded so it keeps following ZOOM_STEPS if the steps are ever changed,
+// and returns -1 if 100% is no longer one of them, which switches the reset off
+// instead of jumping to some arbitrary step.
+function resetZoomIndex(): number {
+    return state.ZOOM_STEPS.indexOf(100);
+}
+
 export function applyZoom(): void {
     const pct   = state.ZOOM_STEPS[state.zoomIndex];
     const scale = pct / 100;
@@ -26,7 +34,16 @@ export function applyZoom(): void {
     // Only the text changes — the label keeps its fixed font-size and min-width,
     // so "60%" → "100%" cannot nudge the zoom-in button sideways either.
     const zoomLabel = document.getElementById('zoom-level');
-    if (zoomLabel) zoomLabel.textContent = pct + '%';
+    if (zoomLabel) {
+        zoomLabel.textContent = pct + '%';
+        // Clicking the percentage returns to 100%. The pointer and the tooltip
+        // only appear while that would do something: at 100% there is nothing to
+        // reset, so the label stays a plain readout.
+        const canReset = resetZoomIndex() >= 0 && state.zoomIndex !== resetZoomIndex();
+        zoomLabel.classList.toggle('resettable', canReset);
+        if (canReset) zoomLabel.title = 'Reset zoom to 100%';
+        else zoomLabel.removeAttribute('title');
+    }
 
     state.autoFitCache = null;
 
@@ -56,7 +73,18 @@ export function zoomOut(): void {
     }
 }
 
+export function resetZoom(): void {
+    const target = resetZoomIndex();
+    if (target < 0 || state.zoomIndex === target) return;
+    state.zoomIndex = target;
+    applyZoom();
+    persistZoom();
+}
+
 export function setupZoom(): void {
     document.getElementById('btn-zoom-in')?.addEventListener('click',  zoomIn);
     document.getElementById('btn-zoom-out')?.addEventListener('click', zoomOut);
+    // The percentage between the two buttons is the reset. applyZoom() decides
+    // whether it currently looks clickable; resetZoom() is a no-op at 100%.
+    document.getElementById('zoom-level')?.addEventListener('click', resetZoom);
 }


### PR DESCRIPTION
The percentage between the two buttons is now the reset: click it and the grid returns to 100%.

<img width="208" height="81" alt="image" src="https://github.com/user-attachments/assets/59e0a8d2-1948-4709-bff1-3e5043641aa6" />
